### PR TITLE
Fix: Resolve post-login 404 and improve auth routing

### DIFF
--- a/rent-ease/src/pages/NotFoundPage.jsx
+++ b/rent-ease/src/pages/NotFoundPage.jsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { Box, Typography, Button, Container } from '@mui/material';
+import { Link as RouterLink } from 'react-router-dom';
+
+const NotFoundPage = () => {
+  return (
+    <Container component="main" maxWidth="sm">
+      <Box
+        sx={{
+          marginTop: 8,
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          textAlign: 'center',
+        }}
+      >
+        <Typography variant="h1" component="h1" gutterBottom sx={{ fontWeight: 'bold', color: 'primary.main' }}>
+          404
+        </Typography>
+        <Typography variant="h5" component="h2" gutterBottom>
+          Page Not Found
+        </Typography>
+        <Typography variant="body1" color="textSecondary" paragraph>
+          The page you are looking for might have been removed, had its name changed, or is temporarily unavailable.
+        </Typography>
+        <Button
+          component={RouterLink}
+          to="/auth/login"
+          variant="contained"
+          color="primary"
+          sx={{ mt: 3 }}
+        >
+          Go to Login
+        </Button>
+      </Box>
+    </Container>
+  );
+};
+
+export default NotFoundPage;

--- a/rent-ease/src/pages/auth/LoginPage.jsx
+++ b/rent-ease/src/pages/auth/LoginPage.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Formik, Form, Field } from 'formik';
 import * as Yup from 'yup';
-import { useNavigate, Link as RouterLink } from 'react-router-dom';
+import { useNavigate, Link as RouterLink, useLocation } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 import { loginUser, clearAuthError } from '../../store/slices/authSlice';
 import { TextField, Button, Typography, Box, Grid, Link, CircularProgress } from '@mui/material';
@@ -9,6 +9,7 @@ import AuthLayout from '../../components/common/AuthLayout'; // Import AuthLayou
 
 const LoginPage = () => {
   const navigate = useNavigate();
+  const location = useLocation(); // Call useLocation
   const dispatch = useDispatch();
   const { loading, error } = useSelector((state) => state.auth);
 
@@ -28,7 +29,13 @@ const LoginPage = () => {
       const action = await dispatch(loginUser(values));
       if (loginUser.fulfilled.match(action)) {
         const user = action.payload.user;
-        navigate(user.userType === 'owner' ? '/owner/dashboard' : '/tenant/dashboard');
+        const from = location.state?.from?.pathname;
+        const defaultDashboard = user.userType === 'owner' ? '/owner/dashboard' : '/tenant/dashboard';
+        let redirectTo = defaultDashboard;
+        if (from && from !== '/auth/login' && from !== '/auth/signup') {
+          redirectTo = from;
+        }
+        navigate(redirectTo, { replace: true });
       }
     } catch (err) {
       console.error("Login submission error:", err);

--- a/rent-ease/src/routes/index.js
+++ b/rent-ease/src/routes/index.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
+import { useSelector } from 'react-redux'; // Import useSelector
 
 // Layouts
 import AuthLayout from '../components/common/AuthLayout';
@@ -17,17 +18,44 @@ import AddRoomPage from '../pages/owner/room/AddRoomPage';
 import EditRoomPage from '../pages/owner/room/EditRoomPage';
 import RoomDetailPage from '../pages/owner/room/RoomDetailPage'; 
 import TenantRoomDetailPage from '../pages/tenant/room/TenantRoomDetailPage'; // Import TenantRoomDetailPage
+import NotFoundPage from '../pages/NotFoundPage'; // Import NotFoundPage
 
 // Protected Route
 import ProtectedRoute from './ProtectedRoute';
+
+// AuthRedirectWrapper Component
+const AuthRedirectWrapper = ({ children }) => {
+  const { isAuthenticated, user } = useSelector((state) => state.auth);
+
+  if (isAuthenticated) {
+    const dashboardPath = user?.userType === 'owner' ? '/owner/dashboard' : '/tenant/dashboard';
+    return <Navigate to={dashboardPath} replace />;
+  }
+
+  return children;
+};
 
 const AppRouter = () => {
   return (
     <BrowserRouter>
       <Routes>
         {/* Auth Routes */}
-        <Route path="/auth/login" element={<AuthLayout><LoginPage /></AuthLayout>} />
-        <Route path="/auth/signup" element={<AuthLayout><SignupPage /></AuthLayout>} />
+        <Route 
+          path="/auth/login" 
+          element={
+            <AuthRedirectWrapper>
+              <AuthLayout><LoginPage /></AuthLayout>
+            </AuthRedirectWrapper>
+          } 
+        />
+        <Route 
+          path="/auth/signup" 
+          element={
+            <AuthRedirectWrapper>
+              <AuthLayout><SignupPage /></AuthLayout>
+            </AuthRedirectWrapper>
+          } 
+        />
 
         {/* Owner Routes - Protected */}
         <Route 
@@ -131,6 +159,9 @@ const AppRouter = () => {
             <Navigate to="/auth/login" replace />
           } 
         />
+
+        {/* Catch-all for undefined routes */}
+        <Route path="*" element={<NotFoundPage />} />
       </Routes>
     </BrowserRouter>
   );


### PR DESCRIPTION
This commit addresses an issue where you might encounter a 404 page or incorrect redirection after logging in.

Key changes:
- Modified `LoginPage.jsx` to intelligently redirect you:
    - Prioritizes `location.state.from` to return you to your intended page post-login.
    - Defaults to your user-specific dashboard if `location.state.from` is not set or is an auth page itself (e.g. /auth/login).
- Added `NotFoundPage.jsx` to provide a user-friendly message for undefined routes. This was already partially implemented by having a catch-all route, but the component itself was added.
- Enhanced auth routes (`/auth/login`, `/auth/signup`) by introducing an `AuthRedirectWrapper`:
    - Prevents already authenticated users from viewing login or signup pages.
    - Redirects authenticated users directly to their respective dashboards.

These changes aim to provide a smoother and more intuitive user experience during and after authentication.